### PR TITLE
Don't shadow global property for demos to work in Safari

### DIFF
--- a/src/demo/build-demos.js
+++ b/src/demo/build-demos.js
@@ -8,5 +8,5 @@ function buildDemo(element) {
     element.innerHTML = `<h2>&lt;${demoName}/&gt;</h2><div><${demoName} class="${classname}"/></div>`
 }
 
-const demos = document.getElementById("demos");
-Array.prototype.forEach.call(demos.children, buildDemo);
+const demoEl = document.getElementById("demos");
+Array.prototype.forEach.call(demoEl.children, buildDemo);


### PR DESCRIPTION
This is the error you get in Safari when trying to run the demo:
<img width="536" alt="screen shot 2016-12-05 at 8 36 08 am" src="https://cloud.githubusercontent.com/assets/228341/20886873/2ce8994c-bac6-11e6-952a-0da96d290b66.png">

Caused by the `demo` id and trying to define a global `demo` variable.
